### PR TITLE
Gcc pre 9 workaround

### DIFF
--- a/ext/zindosteg/bmp.cpp
+++ b/ext/zindosteg/bmp.cpp
@@ -6,7 +6,7 @@
 namespace zindorsky {
 namespace steganography {
 
-bmp_provider::bmp_provider( std::filesystem::path const& filename )
+bmp_provider::bmp_provider( filesystem::path const& filename )
 	: bmp_provider( utils::load_from_file(filename) )
 {
 }
@@ -72,7 +72,7 @@ byte_vector bmp_provider::commit_to_memory()
 	return file_;
 }
 
-void bmp_provider::commit_to_file(std::filesystem::path const& file)
+void bmp_provider::commit_to_file(filesystem::path const& file)
 {
 	utils::save_to_file(file, file_);
 }

--- a/ext/zindosteg/bmp.h
+++ b/ext/zindosteg/bmp.h
@@ -8,7 +8,7 @@ namespace steganography {
 
 class bmp_provider : public provider_t {
 public:
-	explicit bmp_provider( std::filesystem::path const& filename );
+	explicit bmp_provider( filesystem::path const& filename );
 	bmp_provider(byte const* data, size_t size);
 	explicit bmp_provider(byte_vector const& data);
 	explicit bmp_provider(byte_vector && data);
@@ -25,7 +25,7 @@ public:
 	virtual byte & access_indexed_data( index_t index ) override;
 	virtual byte const& access_indexed_data( index_t index ) const override;
 	virtual byte_vector commit_to_memory() override;
-	virtual void commit_to_file(std::filesystem::path const& file) override;
+	virtual void commit_to_file(filesystem::path const& file) override;
 	virtual byte_vector salt() const override;
 
 private:

--- a/ext/zindosteg/device.cpp
+++ b/ext/zindosteg/device.cpp
@@ -7,7 +7,7 @@ namespace steganography {
 
 enum { max_length_sz = 9, nybble_span = 15, byte_span = nybble_span*2, };
 
-device_t::device_t( std::filesystem::path const& carrier_file, std::string const& password, bool open_existing_payload, bool throw_on_open_existing_fail )
+device_t::device_t( filesystem::path const& carrier_file, std::string const& password, bool open_existing_payload, bool throw_on_open_existing_fail )
 	: device_t( provider_t::load(carrier_file), password, open_existing_payload, throw_on_open_existing_fail )
 {
 	carrier_file_ = carrier_file;
@@ -117,7 +117,7 @@ void device_t::flush()
 	}
 }
 
-void device_t::write_to_file(std::filesystem::path const& outfile)
+void device_t::write_to_file(filesystem::path const& outfile)
 {
 	if (dirty_) {
 		write_payload_length();

--- a/ext/zindosteg/device.h
+++ b/ext/zindosteg/device.h
@@ -4,7 +4,7 @@
 #include "provider.h"
 #include "permutator.h"
 #include <stdexcept>
-#include <filesystem>
+#include "steg_defs.h"
 
 namespace zindorsky {
 namespace steganography {
@@ -21,7 +21,7 @@ public:
 	//If "open_existing_payload" is true, a check will be made for a valid payload length (and possibly other parameters).
 	//If the check fails then if throw_on_open_existing_fail is true a payload_extraction_error exception will be thrown. If throw_on_open_existing_fail is false, the intitial size will be set to zero.
 	//If "open_existing_payload" is false, no check will be made and a new length will be written when the device is closed.
-	device_t(std::filesystem::path const& carrier_file, std::string const& password, bool open_existing_payload, bool throw_on_open_existing_fail = true);
+	device_t(filesystem::path const& carrier_file, std::string const& password, bool open_existing_payload, bool throw_on_open_existing_fail = true);
 	//Takes ownership of provider:
 	device_t(std::unique_ptr<provider_t> provider, std::string const& password, bool open_existing_payload, bool throw_on_open_existing_fail = true);
 
@@ -44,7 +44,7 @@ public:
 	std::streamsize truncate(); //sets eof to current position
 	void flush();
 
-	void write_to_file(std::filesystem::path const& outfile);
+	void write_to_file(filesystem::path const& outfile);
 	byte_vector write_to_memory();
 
 	//Returns salt derived from the carrier.
@@ -52,7 +52,7 @@ public:
 
 private:
 	std::unique_ptr<provider_t>  provider_;
-	std::filesystem::path carrier_file_;
+	filesystem::path carrier_file_;
 	permutator::context shuffler_;
 	std::streamsize max_sz_, payload_sz_;
 	std::streampos pos_;

--- a/ext/zindosteg/extconf.rb
+++ b/ext/zindosteg/extconf.rb
@@ -5,4 +5,6 @@ $srcs = sources.map { |file| "#{file}.cpp" }
 $objs = sources.map { |file| "#{file}.o" } << "zindosteg.o"
 $CPPFLAGS << " -std=c++17 -O2"
 $LDFLAGS << " -lcrypto -ljpeg -lpng"
+$LDFLAGS << " -lstdc++fs" if have_macro("EXPERIMENTAL_FILESYSTEM", "steg_defs.h")
+
 create_makefile("zindosteg/zindosteg")

--- a/ext/zindosteg/file_utils.h
+++ b/ext/zindosteg/file_utils.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include <fstream>
-#include <filesystem>
+#include "steg_defs.h"
 #include <vector>
 
 namespace zindorsky {
 namespace steganography {
 namespace utils {
 
-inline byte_vector load_from_file( std::filesystem::path const& filename )
+inline byte_vector load_from_file( filesystem::path const& filename )
 {
 	std::ifstream f(filename.c_str(), std::ios::binary | std::ios_base::in);
 	std::streampos sz = f.seekg(0, std::ios::end).tellg();
@@ -26,7 +26,7 @@ inline byte_vector load_from_file( std::filesystem::path const& filename )
 	return buffer;
 }
 
-inline void save_to_file( std::filesystem::path const& filename, byte_vector const& data )
+inline void save_to_file( filesystem::path const& filename, byte_vector const& data )
 {
 	std::ofstream f(filename.c_str(), std::ios::binary | std::ios::out);
 	f.write(reinterpret_cast<char const*>(data.data()), data.size());

--- a/ext/zindosteg/jpeg.cpp
+++ b/ext/zindosteg/jpeg.cpp
@@ -6,7 +6,7 @@
 namespace zindorsky {
 namespace steganography {
 
-jpeg_provider::jpeg_provider( std::filesystem::path const& filename )
+jpeg_provider::jpeg_provider( filesystem::path const& filename )
 	: jpeg_provider( utils::load_from_file(filename) )
 {
 }
@@ -70,7 +70,7 @@ byte_vector jpeg_provider::commit_to_memory()
 	return jinfo_.save_to_memory();
 }
 
-void jpeg_provider::commit_to_file(std::filesystem::path const& file)
+void jpeg_provider::commit_to_file(filesystem::path const& file)
 {
 	jinfo_.save_to_file(file);
 }

--- a/ext/zindosteg/jpeg.h
+++ b/ext/zindosteg/jpeg.h
@@ -9,7 +9,7 @@ namespace steganography {
 
 class jpeg_provider : public provider_t {
 public:
-	explicit jpeg_provider( std::filesystem::path const& filename );
+	explicit jpeg_provider( filesystem::path const& filename );
     explicit jpeg_provider(byte_vector const& data);
     explicit jpeg_provider(byte_vector && data);
     jpeg_provider(byte const* data, size_t size);
@@ -23,7 +23,7 @@ public:
 	virtual byte & access_indexed_data( index_t index ) override;
 	virtual byte const& access_indexed_data( index_t index ) const override;
 	virtual byte_vector commit_to_memory() override;
-	virtual void commit_to_file(std::filesystem::path const& file) override;
+	virtual void commit_to_file(filesystem::path const& file) override;
 	virtual byte_vector salt() const override;
 
 private:

--- a/ext/zindosteg/jpeg_helpers.cpp
+++ b/ext/zindosteg/jpeg_helpers.cpp
@@ -14,7 +14,7 @@ namespace zindorsky {
 namespace steganography {
 namespace jpeg {
 
-decompress_ctx::decompress_ctx( std::filesystem::path const& filename )
+decompress_ctx::decompress_ctx( filesystem::path const& filename )
 	: decompress_ctx( utils::load_from_file(filename) )
 {
 }
@@ -80,7 +80,7 @@ decompress_ctx::~decompress_ctx()
 	}
 }
 
-void decompress_ctx::save_to_file( std::filesystem::path const& filename )
+void decompress_ctx::save_to_file( filesystem::path const& filename )
 {
 	FILE* file = ::fopen( filename.c_str(), "wb" );
 	if(!file) {

--- a/ext/zindosteg/jpeg_helpers.h
+++ b/ext/zindosteg/jpeg_helpers.h
@@ -4,7 +4,6 @@
 #include "steg_defs.h"
 #include <cstdio>
 #include <jpeglib.h>
-#include <filesystem>
 #include <vector>
 
 //error handling callback for jpeg lib
@@ -21,7 +20,7 @@ public:
 
 class decompress_ctx {
 public:
-	explicit decompress_ctx( std::filesystem::path const& filename );
+	explicit decompress_ctx( filesystem::path const& filename );
 	decompress_ctx(byte const* data, size_t size);
 	explicit decompress_ctx(byte_vector const& data);
 	explicit decompress_ctx(byte_vector && data);
@@ -39,7 +38,7 @@ public:
 
 	jvirt_barray_ptr* coefficients() const { return coeff_; }
 
-	void save_to_file( std::filesystem::path const& filename );
+	void save_to_file( filesystem::path const& filename );
 	byte_vector save_to_memory();
 
 private:

--- a/ext/zindosteg/loader.cpp
+++ b/ext/zindosteg/loader.cpp
@@ -12,7 +12,7 @@ namespace {
 	const size_t min_header_sz = 0x40;
 }
 
-std::unique_ptr<provider_t> provider_t::load(std::filesystem::path const& file)
+std::unique_ptr<provider_t> provider_t::load(filesystem::path const& file)
 {
 	std::ifstream source(file.c_str());
 	//read first few bytes for header

--- a/ext/zindosteg/loader.cpp
+++ b/ext/zindosteg/loader.cpp
@@ -4,6 +4,7 @@
 #include "bmp.h"
 #include "jpeg.h"
 #include "png_provider.h"
+#include "string.h"
 
 namespace zindorsky {
 namespace steganography {

--- a/ext/zindosteg/png_provider.cpp
+++ b/ext/zindosteg/png_provider.cpp
@@ -38,7 +38,7 @@ void flush_data(png_structp)
 
 const byte png_provider::signature[8] = {0x89,0x50,0x4E,0x47,0x0D,0x0A,0x1A,0x0A};
 
-png_provider::png_provider(std::filesystem::path const& filename)
+png_provider::png_provider(filesystem::path const& filename)
     : png_provider( utils::load_from_file(filename) )
 {
 }
@@ -126,7 +126,7 @@ byte_vector png_provider::commit_to_memory()
 	return data;
 }
 
-void png_provider::commit_to_file(std::filesystem::path const& file)
+void png_provider::commit_to_file(filesystem::path const& file)
 {
   FILE *f = fopen(file.string().c_str(), "wb");
   png_write_ctx write_ctx;

--- a/ext/zindosteg/png_provider.cpp
+++ b/ext/zindosteg/png_provider.cpp
@@ -1,6 +1,7 @@
 #include "png_provider.h"
 #include <exception>
 #include "file_utils.h"
+#include "string.h"
 
 namespace zindorsky {
 namespace steganography {

--- a/ext/zindosteg/png_provider.h
+++ b/ext/zindosteg/png_provider.h
@@ -53,7 +53,7 @@ namespace zindorsky {
 
     class png_provider : public provider_t {
       public:
-        explicit png_provider(std::filesystem::path const& filename);
+        explicit png_provider(filesystem::path const& filename);
         explicit png_provider(byte_vector const& data);
         png_provider(byte const* data, size_t size);
 
@@ -69,7 +69,7 @@ namespace zindorsky {
         virtual byte & access_indexed_data(index_t index) override;
         virtual byte const& access_indexed_data(index_t index) const override;
         virtual byte_vector commit_to_memory() override;
-        virtual void commit_to_file(std::filesystem::path const& file) override;
+        virtual void commit_to_file(filesystem::path const& file) override;
         virtual byte_vector salt() const override;
 
         static const byte signature[8];

--- a/ext/zindosteg/provider.h
+++ b/ext/zindosteg/provider.h
@@ -3,7 +3,6 @@
 #include "steg_defs.h"
 #include <vector>
 #include <memory>
-#include <filesystem>
 #include <cstdint>
 #include <exception>
 
@@ -19,7 +18,7 @@ public:
 class provider_t {
 public:
 	//Loads from file.
-	static std::unique_ptr<provider_t> load(std::filesystem::path const& file);
+	static std::unique_ptr<provider_t> load(filesystem::path const& file);
 	//Loads from memory. Caller retains ownership of buffer.
 	static std::unique_ptr<provider_t> load(void const* data, size_t size);
 
@@ -33,7 +32,7 @@ public:
 	virtual byte & access_indexed_data(index_t index) = 0;
 	virtual byte const& access_indexed_data( index_t index ) const = 0;
 	virtual byte_vector commit_to_memory() = 0;
-	virtual void commit_to_file(std::filesystem::path const& file) = 0;
+	virtual void commit_to_file(filesystem::path const& file) = 0;
 	virtual byte_vector salt() const = 0;
 
 };

--- a/ext/zindosteg/steg_defs.h
+++ b/ext/zindosteg/steg_defs.h
@@ -13,7 +13,7 @@ namespace zindorsky {
 using byte = unsigned char;
 using byte_vector = std::vector<byte>;
 
-#if EXPERIMENTAL_FILESYSTEM
+#if defined(EXPERIMENTAL_FILESYSTEM)
 # include <experimental/filesystem>
 namespace filesystem = std::experimental::filesystem;
 #else

--- a/ext/zindosteg/steg_defs.h
+++ b/ext/zindosteg/steg_defs.h
@@ -1,10 +1,24 @@
 #pragma once
 
 #include <vector>
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
+# define EXPERIMENTAL_FILESYSTEM
+# include <experimental/filesystem>
+#else
+# include <filesystem>
+#endif
 
 namespace zindorsky {
 
 using byte = unsigned char;
 using byte_vector = std::vector<byte>;
+
+#if EXPERIMENTAL_FILESYSTEM
+# include <experimental/filesystem>
+namespace filesystem = std::experimental::filesystem;
+#else
+# include <filesystem>
+namespace filesystem = std::filesystem;
+#endif
 
 } // namespace zindorsky

--- a/ext/zindosteg/zindosteg.cpp
+++ b/ext/zindosteg/zindosteg.cpp
@@ -122,7 +122,7 @@ namespace {
   class device_interface {
   public:
     device_interface(std::string const& carrier_file, std::string const& password, mode const& mode = "r"s)
-			: device_interface{steganography::device_t{std::filesystem::path{carrier_file}, password, !mode.create, !mode.append}, password, mode}
+			: device_interface{steganography::device_t{filesystem::path{carrier_file}, password, !mode.create, !mode.append}, password, mode}
     {
       if (!mode_.create) {
         //Check hmac to make sure password is correct, payload hasn't been tampered with, etc.


### PR DESCRIPTION
When gcc version < 9, we have to use `std::experimental::filesystem` instead of the standard `std::filesystem`.